### PR TITLE
Fix check for both primer sequences appearing in assembled contig

### DIFF
--- a/pal_filter.py
+++ b/pal_filter.py
@@ -456,8 +456,10 @@ if args.assembly:
 
                 # check that both primer sequences can be seen in the
                 # assembled contig
-                if y or ReverseComplement1(y) in assembly_no_id and z or \
-                                    ReverseComplement1(z) in assembly_no_id:
+                if ((y in assembly_no_id) or \
+                    (ReverseComplement1(y) in assembly_no_id)) and \
+                    ((z in assembly_no_id) or \
+                    (ReverseComplement1(z) in assembly_no_id)):
                     if y in assembly_no_id:
                         # get the positions of the primers in the assembly
                         # (can be used to predict fragment length)


### PR DESCRIPTION
Hi Graeme

This attempts to fix what I believe is a bug in the conditional statement for testing whether both primer sequences can be seen in the assembled contig. The statement looks ambiguous and doesn't appear to be consistent with the subsequent code for setting `F_position` and `R_position`.

As originally written it will be true when:
- either `y` is set or `ReverseComplement1(y)` appears in `assembly_no_id`, and
- either `z` is set or `ReverseComplement1(z)` appears in `assembly_no_id`

I believe the actual intention is that it should be true when:
- either `y` appears in `assembly_no_id` or `ReverseComplement1(y)` appears in `assembly_no_id`, and
- either `z` appears in `assembly_no_id` or `ReverseComplement1(z)` appears in `assembly_no_id`
